### PR TITLE
Feature/get remittance list

### DIFF
--- a/src/main/java/com/sskkilm/cashflow/controller/RemittanceController.java
+++ b/src/main/java/com/sskkilm/cashflow/controller/RemittanceController.java
@@ -6,13 +6,17 @@ import com.sskkilm.cashflow.entity.User;
 import com.sskkilm.cashflow.service.RemittanceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,22 +33,28 @@ public class RemittanceController {
     }
 
     @GetMapping("/remittances/{accountId}")
-    public List<RemittanceDto> getRemittanceList(
+    public Slice<RemittanceDto> getRemittanceList(
+            @PageableDefault(
+                    size = 30, sort = "createdAt", direction = Sort.Direction.DESC
+            ) Pageable pageable,
             @PathVariable Long accountId,
             @AuthenticationPrincipal User user
     ) {
-        return remittanceService.getRemittanceList(accountId, user);
+        return remittanceService.getRemittanceList(pageable, accountId, user);
     }
 
     @GetMapping(value = "/remittances/{accountId}", params = {"startDate", "endDate"})
-    public List<RemittanceDto> getRemittanceList(
+    public Page<RemittanceDto> getRemittanceList(
+            @PageableDefault(
+                    size = 30, sort = "createdAt", direction = Sort.Direction.DESC
+            ) Pageable pageable,
             @PathVariable Long accountId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @AuthenticationPrincipal User user
     ) {
         return remittanceService.getRemittanceList(
-                accountId, user, startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX)
+                pageable, accountId, user, startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX)
         );
     }
 }

--- a/src/main/java/com/sskkilm/cashflow/controller/RemittanceController.java
+++ b/src/main/java/com/sskkilm/cashflow/controller/RemittanceController.java
@@ -1,14 +1,18 @@
 package com.sskkilm.cashflow.controller;
 
 import com.sskkilm.cashflow.dto.CreateRemittanceDto;
+import com.sskkilm.cashflow.dto.RemittanceDto;
 import com.sskkilm.cashflow.entity.User;
 import com.sskkilm.cashflow.service.RemittanceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,5 +26,25 @@ public class RemittanceController {
             @AuthenticationPrincipal User user
     ) {
         return remittanceService.createRemittance(request, user);
+    }
+
+    @GetMapping("/remittances/{accountId}")
+    public List<RemittanceDto> getRemittanceList(
+            @PathVariable Long accountId,
+            @AuthenticationPrincipal User user
+    ) {
+        return remittanceService.getRemittanceList(accountId, user);
+    }
+
+    @GetMapping(value = "/remittances/{accountId}", params = {"startDate", "endDate"})
+    public List<RemittanceDto> getRemittanceList(
+            @PathVariable Long accountId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @AuthenticationPrincipal User user
+    ) {
+        return remittanceService.getRemittanceList(
+                accountId, user, startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX)
+        );
     }
 }

--- a/src/main/java/com/sskkilm/cashflow/dto/RemittanceDto.java
+++ b/src/main/java/com/sskkilm/cashflow/dto/RemittanceDto.java
@@ -1,0 +1,23 @@
+package com.sskkilm.cashflow.dto;
+
+import com.sskkilm.cashflow.entity.Remittance;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record RemittanceDto(
+        String receivingAccountNumber,
+        Integer remittanceAmount,
+        Integer accountBalanceSnapshot,
+        LocalDateTime createdAt
+) {
+    public static RemittanceDto fromEntity(Remittance remittance) {
+        return RemittanceDto.builder()
+                .receivingAccountNumber(remittance.getReceivingAccountNumber())
+                .remittanceAmount(remittance.getAmount())
+                .accountBalanceSnapshot(remittance.getAccountBalanceSnapshot())
+                .createdAt(remittance.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/sskkilm/cashflow/entity/Remittance.java
+++ b/src/main/java/com/sskkilm/cashflow/entity/Remittance.java
@@ -12,6 +12,9 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Entity
+@Table(indexes = {
+        @Index(name = "idx_account_createdAt", columnList = "account_id, created_at DESC")
+})
 @EntityListeners(AuditingEntityListener.class)
 public class Remittance {
     @Id

--- a/src/main/java/com/sskkilm/cashflow/enums/RemittanceErrorCode.java
+++ b/src/main/java/com/sskkilm/cashflow/enums/RemittanceErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum RemittanceErrorCode implements ErrorCode {
 
     REMITTANCE_AND_RECEIVING_ACCOUNT_SAME(HttpStatus.BAD_REQUEST, "송금 계좌와 수금 계좌가 동일합니다."),
-    RECEIVING_ACCOUNT_CAN_NOT_USE(HttpStatus.BAD_REQUEST, "수금 계좌가 비활성 상태입니다.")
+    RECEIVING_ACCOUNT_CAN_NOT_USE(HttpStatus.BAD_REQUEST, "수금 계좌가 비활성 상태입니다."),
+    REMITTANCE_HISTORY_INQUIRY_PERIOD_LIMITED(HttpStatus.BAD_REQUEST, "송금이력 조회는 시작일부터 최대 1년까지 가능합니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/sskkilm/cashflow/repository/RemittanceRepository.java
+++ b/src/main/java/com/sskkilm/cashflow/repository/RemittanceRepository.java
@@ -2,23 +2,27 @@ package com.sskkilm.cashflow.repository;
 
 import com.sskkilm.cashflow.entity.Account;
 import com.sskkilm.cashflow.entity.Remittance;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Repository
 public interface RemittanceRepository extends JpaRepository<Remittance, Long> {
-    List<Remittance> findAllByAccountOrderByCreatedAtDesc(Account account);
+    Slice<Remittance> findAllByAccount(Account account, Pageable pageable);
 
-    @Query("Select r from Remittance r Join r.account a Where a = :account " +
-            "And r.createdAt Between :startDate And :endDate Order By r.createdAt DESC")
-    List<Remittance> findAllByAccountOrderByCreatedAtBetweenDesc(
+    @Query("Select r from Remittance r Where r.account = :account " +
+            "And r.createdAt Between :startDate And :endDate")
+    Page<Remittance> findAllByAccountAndCreatedAt(
             @Param("account") Account account,
             @Param("startDate") LocalDateTime startDate,
-            @Param("endDate") LocalDateTime endDate
+            @Param("endDate") LocalDateTime endDate,
+            Pageable pageable
     );
+
 }

--- a/src/main/java/com/sskkilm/cashflow/repository/RemittanceRepository.java
+++ b/src/main/java/com/sskkilm/cashflow/repository/RemittanceRepository.java
@@ -1,9 +1,24 @@
 package com.sskkilm.cashflow.repository;
 
+import com.sskkilm.cashflow.entity.Account;
 import com.sskkilm.cashflow.entity.Remittance;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface RemittanceRepository extends JpaRepository<Remittance, Long> {
+    List<Remittance> findAllByAccountOrderByCreatedAtDesc(Account account);
+
+    @Query("Select r from Remittance r Join r.account a Where a = :account " +
+            "And r.createdAt Between :startDate And :endDate Order By r.createdAt DESC")
+    List<Remittance> findAllByAccountOrderByCreatedAtBetweenDesc(
+            @Param("account") Account account,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
 }

--- a/src/main/java/com/sskkilm/cashflow/service/RemittanceService.java
+++ b/src/main/java/com/sskkilm/cashflow/service/RemittanceService.java
@@ -1,6 +1,7 @@
 package com.sskkilm.cashflow.service;
 
 import com.sskkilm.cashflow.dto.CreateRemittanceDto;
+import com.sskkilm.cashflow.dto.RemittanceDto;
 import com.sskkilm.cashflow.entity.Account;
 import com.sskkilm.cashflow.entity.Remittance;
 import com.sskkilm.cashflow.entity.User;
@@ -14,7 +15,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -60,5 +64,35 @@ public class RemittanceService {
         );
 
         return CreateRemittanceDto.Response.fromEntity(remittance);
+    }
+
+    public List<RemittanceDto> getRemittanceList(Long accountId, User user) {
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new CustomException(AccountErrorCode.ACCOUNT_NOT_FOUND));
+        if (!Objects.equals(account.getUser().getId(), user.getId())) {
+            throw new CustomException(AccountErrorCode.ACCOUNT_USER_UN_MATCH);
+        }
+
+        List<Remittance> remittanceList = remittanceRepository
+                .findAllByAccountOrderByCreatedAtDesc(account);
+
+        return remittanceList.stream().map(RemittanceDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public List<RemittanceDto> getRemittanceList(
+            Long accountId, User user, LocalDateTime startDate, LocalDateTime endDate
+    ) {
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new CustomException(AccountErrorCode.ACCOUNT_NOT_FOUND));
+        if (!Objects.equals(account.getUser().getId(), user.getId())) {
+            throw new CustomException(AccountErrorCode.ACCOUNT_USER_UN_MATCH);
+        }
+
+        List<Remittance> remittanceList = remittanceRepository
+                .findAllByAccountOrderByCreatedAtBetweenDesc(account, startDate, endDate);
+
+        return remittanceList.stream().map(RemittanceDto::fromEntity)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/sskkilm/cashflow/controller/RemittanceControllerTest.java
+++ b/src/test/java/com/sskkilm/cashflow/controller/RemittanceControllerTest.java
@@ -15,6 +15,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -192,21 +196,24 @@ class RemittanceControllerTest {
                 .password("root")
                 .role(Authority.ROLE_USER)
                 .build();
-        given(remittanceService.getRemittanceList(anyLong(), any()))
-                .willReturn(List.of(
-                                RemittanceDto.builder()
-                                        .receivingAccountNumber("1122334455")
-                                        .remittanceAmount(1000)
-                                        .accountBalanceSnapshot(0)
-                                        .createdAt(
-                                                LocalDateTime.of(
-                                                        2024, 5, 5,
-                                                        0, 0
-                                                )
-                                        )
-                                        .build()
+        List<RemittanceDto> remittanceDtos = List.of(
+                RemittanceDto.builder()
+                        .receivingAccountNumber("1122334455")
+                        .remittanceAmount(1000)
+                        .accountBalanceSnapshot(0)
+                        .createdAt(
+                                LocalDateTime.of(
+                                        2024, 5, 5,
+                                        0, 0
+                                )
                         )
-                );
+                        .build()
+        );
+        PageRequest pageRequest = PageRequest.of(
+                0, 30, Sort.by(Sort.Direction.DESC, "created_at")
+        );
+        given(remittanceService.getRemittanceList(any(), anyLong(), any()))
+                .willReturn(new SliceImpl<>(remittanceDtos, pageRequest, false));
 
         //when
         //then
@@ -214,13 +221,13 @@ class RemittanceControllerTest {
                         .with(user(user))
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].receivingAccountNumber")
+                .andExpect(jsonPath("$.content[0].receivingAccountNumber")
                         .value("1122334455"))
-                .andExpect(jsonPath("$[0].remittanceAmount")
+                .andExpect(jsonPath("$.content[0].remittanceAmount")
                         .value(1000))
-                .andExpect(jsonPath("$[0].accountBalanceSnapshot")
+                .andExpect(jsonPath("$.content[0].accountBalanceSnapshot")
                         .value(0))
-                .andExpect(jsonPath("$[0].createdAt")
+                .andExpect(jsonPath("$.content[0].createdAt")
                         .value("2024-05-05T00:00:00"))
                 .andDo(print());
     }
@@ -235,21 +242,24 @@ class RemittanceControllerTest {
                 .password("root")
                 .role(Authority.ROLE_USER)
                 .build();
-        given(remittanceService.getRemittanceList(anyLong(), any(), any(), any()))
-                .willReturn(List.of(
-                                RemittanceDto.builder()
-                                        .receivingAccountNumber("1122334455")
-                                        .remittanceAmount(1000)
-                                        .accountBalanceSnapshot(0)
-                                        .createdAt(
-                                                LocalDateTime.of(
-                                                        2024, 5, 5,
-                                                        0, 0
-                                                )
-                                        )
-                                        .build()
+        List<RemittanceDto> remittanceDtos = List.of(
+                RemittanceDto.builder()
+                        .receivingAccountNumber("1122334455")
+                        .remittanceAmount(1000)
+                        .accountBalanceSnapshot(0)
+                        .createdAt(
+                                LocalDateTime.of(
+                                        2024, 5, 5,
+                                        0, 0
+                                )
                         )
-                );
+                        .build()
+        );
+        PageRequest pageRequest = PageRequest.of(
+                0, 30, Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+        given(remittanceService.getRemittanceList(any(), anyLong(), any(), any(), any()))
+                .willReturn(new PageImpl<>(remittanceDtos, pageRequest, 1));
 
         //when
         //then
@@ -259,13 +269,13 @@ class RemittanceControllerTest {
                         .param("endDate", "2024-05-10")
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].receivingAccountNumber")
+                .andExpect(jsonPath("$.content[0].receivingAccountNumber")
                         .value("1122334455"))
-                .andExpect(jsonPath("$[0].remittanceAmount")
+                .andExpect(jsonPath("$.content[0].remittanceAmount")
                         .value(1000))
-                .andExpect(jsonPath("$[0].accountBalanceSnapshot")
+                .andExpect(jsonPath("$.content[0].accountBalanceSnapshot")
                         .value(0))
-                .andExpect(jsonPath("$[0].createdAt")
+                .andExpect(jsonPath("$.content[0].createdAt")
                         .value("2024-05-05T00:00:00"))
                 .andDo(print());
     }

--- a/src/test/java/com/sskkilm/cashflow/controller/RemittanceControllerTest.java
+++ b/src/test/java/com/sskkilm/cashflow/controller/RemittanceControllerTest.java
@@ -3,6 +3,7 @@ package com.sskkilm.cashflow.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sskkilm.cashflow.config.SecurityConfiguration;
 import com.sskkilm.cashflow.dto.CreateRemittanceDto;
+import com.sskkilm.cashflow.dto.RemittanceDto;
 import com.sskkilm.cashflow.entity.User;
 import com.sskkilm.cashflow.enums.Authority;
 import com.sskkilm.cashflow.enums.GlobalErrorCode;
@@ -18,10 +19,13 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -175,6 +179,94 @@ class RemittanceControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode").value("INVALID_REQUEST"))
                 .andExpect(jsonPath("$.message").value(GlobalErrorCode.INVALID_REQUEST.getMessage()))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("모든 송금 내역 조회")
+    void getRemittanceList() throws Exception {
+        //given
+        User user = User.builder()
+                .id(1L)
+                .loginId("root")
+                .password("root")
+                .role(Authority.ROLE_USER)
+                .build();
+        given(remittanceService.getRemittanceList(anyLong(), any()))
+                .willReturn(List.of(
+                                RemittanceDto.builder()
+                                        .receivingAccountNumber("1122334455")
+                                        .remittanceAmount(1000)
+                                        .accountBalanceSnapshot(0)
+                                        .createdAt(
+                                                LocalDateTime.of(
+                                                        2024, 5, 5,
+                                                        0, 0
+                                                )
+                                        )
+                                        .build()
+                        )
+                );
+
+        //when
+        //then
+        mockMvc.perform(get("/remittances/1")
+                        .with(user(user))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].receivingAccountNumber")
+                        .value("1122334455"))
+                .andExpect(jsonPath("$[0].remittanceAmount")
+                        .value(1000))
+                .andExpect(jsonPath("$[0].accountBalanceSnapshot")
+                        .value(0))
+                .andExpect(jsonPath("$[0].createdAt")
+                        .value("2024-05-05T00:00:00"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("기간 내 송금 내역 조회")
+    void getRemittanceListBetween() throws Exception {
+        //given
+        User user = User.builder()
+                .id(1L)
+                .loginId("root")
+                .password("root")
+                .role(Authority.ROLE_USER)
+                .build();
+        given(remittanceService.getRemittanceList(anyLong(), any(), any(), any()))
+                .willReturn(List.of(
+                                RemittanceDto.builder()
+                                        .receivingAccountNumber("1122334455")
+                                        .remittanceAmount(1000)
+                                        .accountBalanceSnapshot(0)
+                                        .createdAt(
+                                                LocalDateTime.of(
+                                                        2024, 5, 5,
+                                                        0, 0
+                                                )
+                                        )
+                                        .build()
+                        )
+                );
+
+        //when
+        //then
+        mockMvc.perform(get("/remittances/1")
+                        .with(user(user))
+                        .param("startDate", "2024-05-01")
+                        .param("endDate", "2024-05-10")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].receivingAccountNumber")
+                        .value("1122334455"))
+                .andExpect(jsonPath("$[0].remittanceAmount")
+                        .value(1000))
+                .andExpect(jsonPath("$[0].accountBalanceSnapshot")
+                        .value(0))
+                .andExpect(jsonPath("$[0].createdAt")
+                        .value("2024-05-05T00:00:00"))
                 .andDo(print());
     }
 }

--- a/src/test/java/com/sskkilm/cashflow/service/RemittanceServiceTest.java
+++ b/src/test/java/com/sskkilm/cashflow/service/RemittanceServiceTest.java
@@ -1,6 +1,7 @@
 package com.sskkilm.cashflow.service;
 
 import com.sskkilm.cashflow.dto.CreateRemittanceDto;
+import com.sskkilm.cashflow.dto.RemittanceDto;
 import com.sskkilm.cashflow.entity.Account;
 import com.sskkilm.cashflow.entity.Remittance;
 import com.sskkilm.cashflow.entity.User;
@@ -19,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -350,5 +352,230 @@ class RemittanceServiceTest {
 
         //then
         assertEquals(RemittanceErrorCode.REMITTANCE_AND_RECEIVING_ACCOUNT_SAME, customException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("모든 송금 내역 조회 성공")
+    void getRemittanceList_success() {
+        //given
+        User user = User.builder()
+                .id(1L)
+                .loginId("root")
+                .password("root")
+                .role(Authority.ROLE_USER)
+                .build();
+        given(accountRepository.findById(anyLong()))
+                .willReturn(Optional.of(
+                        Account.builder()
+                                .id(1L)
+                                .user(user)
+                                .build()
+                ));
+        LocalDateTime createdAt1 = LocalDateTime.of(
+                2024, 5, 5,
+                0, 0
+        );
+        List<Remittance> remittanceList = List.of(
+                Remittance.builder()
+                        .receivingAccountNumber("1122334455")
+                        .amount(1000)
+                        .accountBalanceSnapshot(0)
+                        .createdAt(createdAt1)
+                        .build()
+        );
+        given(remittanceRepository.findAllByAccountOrderByCreatedAtDesc(any()))
+                .willReturn(remittanceList);
+
+        //when
+        List<RemittanceDto> remittanceDtoList = remittanceService.getRemittanceList(1L, user);
+
+        //then
+        assertEquals("1122334455", remittanceDtoList.get(0).receivingAccountNumber());
+        assertEquals(1000, remittanceDtoList.get(0).remittanceAmount());
+        assertEquals(0, remittanceDtoList.get(0).accountBalanceSnapshot());
+        assertEquals(createdAt1, remittanceDtoList.get(0).createdAt());
+    }
+
+    @Test
+    @DisplayName("모든 송금 내역 조회 실패 - 존재하지 않는 계좌")
+    void getRemittanceList_fail_AccountNotFound() {
+        //given
+        User user = User.builder()
+                .id(1L)
+                .loginId("root")
+                .password("root")
+                .role(Authority.ROLE_USER)
+                .build();
+        given(accountRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> remittanceService.getRemittanceList(1L, user)
+        );
+
+        //then
+        assertEquals(AccountErrorCode.ACCOUNT_NOT_FOUND, customException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("모든 송금 내역 조회 실패 - 계좌 소유주 다름")
+    void getRemittanceList_fail_AccountUserUnMatch() {
+        //given
+        User user1 = User.builder()
+                .id(1L)
+                .loginId("root1")
+                .password("root1")
+                .role(Authority.ROLE_USER)
+                .build();
+        User user2 = User.builder()
+                .id(2L)
+                .loginId("root2")
+                .password("root2")
+                .role(Authority.ROLE_USER)
+                .build();
+        given(accountRepository.findById(anyLong()))
+                .willReturn(Optional.of(
+                        Account.builder()
+                                .id(1L)
+                                .user(user1)
+                                .build()
+                ));
+
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> remittanceService.getRemittanceList(1L, user2)
+        );
+
+        //then
+        assertEquals(AccountErrorCode.ACCOUNT_USER_UN_MATCH, customException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("기간 내 송금 내역 조회 성공")
+    void getRemittanceListBetween_success() {
+        //given
+        User user = User.builder()
+                .id(1L)
+                .loginId("root")
+                .password("root")
+                .role(Authority.ROLE_USER)
+                .build();
+        given(accountRepository.findById(anyLong()))
+                .willReturn(Optional.of(
+                        Account.builder()
+                                .id(1L)
+                                .user(user)
+                                .build()
+                ));
+        LocalDateTime createdAt1 = LocalDateTime.of(
+                2024, 5, 5,
+                0, 0
+        );
+        List<Remittance> remittanceList = List.of(
+                Remittance.builder()
+                        .receivingAccountNumber("1122334455")
+                        .amount(1000)
+                        .accountBalanceSnapshot(0)
+                        .createdAt(createdAt1)
+                        .build()
+        );
+        given(remittanceRepository.findAllByAccountOrderByCreatedAtBetweenDesc(
+                any(), any(), any())
+        ).willReturn(remittanceList);
+
+        //when
+        List<RemittanceDto> remittanceDtoList = remittanceService.getRemittanceList(
+                1L, user,
+                LocalDateTime.of(
+                        2024, 5, 1,
+                        0, 0
+                ),
+                LocalDateTime.of(
+                        2024, 5, 10,
+                        0, 0
+                )
+        );
+
+        //then
+        assertEquals("1122334455", remittanceDtoList.get(0).receivingAccountNumber());
+        assertEquals(1000, remittanceDtoList.get(0).remittanceAmount());
+        assertEquals(0, remittanceDtoList.get(0).accountBalanceSnapshot());
+        assertEquals(createdAt1, remittanceDtoList.get(0).createdAt());
+    }
+
+    @Test
+    @DisplayName("기간 내 송금 내역 조회 실패 - 존재하지 않는 계좌")
+    void getRemittanceListBetween_fail_AccountNotFound() {
+        //given
+        User user = User.builder()
+                .id(1L)
+                .loginId("root")
+                .password("root")
+                .role(Authority.ROLE_USER)
+                .build();
+        given(accountRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> remittanceService.getRemittanceList(
+                        1L, user,
+                        LocalDateTime.of(
+                                2024, 5, 1,
+                                0, 0
+                        ),
+                        LocalDateTime.of(
+                                2024, 5, 10,
+                                0, 0
+                        )
+                )
+        );
+
+        //then
+        assertEquals(AccountErrorCode.ACCOUNT_NOT_FOUND, customException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("기간 내 송금 내역 조회 실패 - 계좌 소유주 다름")
+    void getRemittanceListBetween_fail_AccountUserUnMatch() {
+        //given
+        User user1 = User.builder()
+                .id(1L)
+                .loginId("root1")
+                .password("root1")
+                .role(Authority.ROLE_USER)
+                .build();
+        User user2 = User.builder()
+                .id(2L)
+                .loginId("root2")
+                .password("root2")
+                .role(Authority.ROLE_USER)
+                .build();
+        given(accountRepository.findById(anyLong()))
+                .willReturn(Optional.of(
+                        Account.builder()
+                                .id(1L)
+                                .user(user1)
+                                .build()
+                ));
+
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> remittanceService.getRemittanceList(
+                        1L, user2,
+                        LocalDateTime.of(
+                                2024, 5, 1,
+                                0, 0
+                        ),
+                        LocalDateTime.of(
+                                2024, 5, 10,
+                                0, 0
+                        )
+                )
+        );
+
+        //then
+        assertEquals(AccountErrorCode.ACCOUNT_USER_UN_MATCH, customException.getErrorCode());
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
송금 내역 조회 기능 구현 및 테스트코드 작성
로그인중인 사용자 정보는 @AuthenticationPrincipal 어노테이션을 적용하여 메소드 파라미터에 Authentication의 principal
, 즉 User(커스텀한 UserDetails) 객체를 불러왔습니다.
송금 내역 조회 기능은 모든 내역 조회와 기간 내 내역 조회로 구분되며 기간 내 내역 조회 시에는 params 파라미터를 통해 요청이 잘 매핑되도록 구현했습니다.
존재하지 않는 계좌일 경우, 계좌와 소유주가 다른 경우 등 상황에 따른 예외 처리가 진행되었습니다.
기간 내 송금 내역을 송금 일자 기준 내림차순으로 불러오는 쿼리는 조건이 복잡해 JPQL을 직접 정의해 구현했습니다. 
RemittanceDto로 적절한 응답을 내리도록 구현했습니다.
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 기능 개발 구현 및 변경
- [x] 테스트 구현 및 변경
- [ ] 코드 리팩토링
- [ ] 코드가 아닌 그 외의 부분 (설정) 등의 변경
- [ ] 버그 수정

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성
- [x] API 테스트
- [x] 테스트 코드